### PR TITLE
Make fetch_resources check STATICFILES_DIRS so it works better with django's staticfiles module.

### DIFF
--- a/django_xhtml2pdf/utils.py
+++ b/django_xhtml2pdf/utils.py
@@ -26,6 +26,11 @@ def fetch_resources(uri, rel):
     elif uri.startswith(settings.STATIC_URL):
         path = os.path.join(settings.STATIC_ROOT,
                             uri.replace(settings.STATIC_URL, ""))
+        if not os.path.exists(path):
+            for d in settings.STATICFILES_DIRS:
+                path = os.path.join(d, uri.replace(settings.STATIC_URL, ""))
+                if os.path.exists(path):
+                    break
     else:
         raise UnsupportedMediaPathException(
                                 'media urls must start with %s or %s' % (


### PR DESCRIPTION
...(e.g. loop through the STATICFILES_DIRS and see if a desired resource exists anywhere else).
