### PR TITLE
trivial fix for fetch_resources

### DIFF
--- a/django_xhtml2pdf/utils.py
+++ b/django_xhtml2pdf/utils.py
@@ -20,10 +20,10 @@ def fetch_resources(uri, rel):
     `rel` gives a relative path, but it's not used here.
 
     """
-    if uri.startswith(settings.MEDIA_URL):
+    if settings.MEDIA_URL and uri.startswith(settings.MEDIA_URL):
         path = os.path.join(settings.MEDIA_ROOT,
                             uri.replace(settings.MEDIA_URL, ""))
-    elif uri.startswith(settings.STATIC_URL):
+    elif settings.STATIC_URL and uri.startswith(settings.STATIC_URL):
         path = os.path.join(settings.STATIC_ROOT,
                             uri.replace(settings.STATIC_URL, ""))
         if not os.path.exists(path):


### PR DESCRIPTION
fetch_resources fail if no MEDIA_URL is defined. This commit fixes that.
