### PR TITLE
Added ability to support remote URIs

### DIFF
--- a/django_xhtml2pdf/utils.py
+++ b/django_xhtml2pdf/utils.py
@@ -31,6 +31,8 @@ def fetch_resources(uri, rel):
                 path = os.path.join(d, uri.replace(settings.STATIC_URL, ""))
                 if os.path.exists(path):
                     break
+    elif uri.startswith("http://") or uri.startswith("https://"):
+        path = uri
     else:
         raise UnsupportedMediaPathException(
                                 'media urls must start with %s or %s' % (
@@ -47,17 +49,17 @@ def generate_pdf_template_object(template_object, file_object, context):
     return file_object
 
 #===============================================================================
-# Main 
+# Main
 #===============================================================================
 
 def generate_pdf(template_name, file_object=None, context=None): # pragma: no cover
     """
     Uses the xhtml2pdf library to render a PDF to the passed file_object, from the
     given template name.
-    
+
     This returns the passed-in file object, filled with the actual PDF data.
     In case the passed in file object is none, it will return a StringIO instance.
-    
+
     """
     if not file_object:
         file_object = StringIO.StringIO()


### PR DESCRIPTION
Including images in a template that are remote (we use amazon S3 for our static content) is supported in pisa by passing a uri.  As mentioned in the commit comment, this could also be done with a regex, not sure what would be most efficient.
